### PR TITLE
Update and clause of Peewee query

### DIFF
--- a/src/services/user.py
+++ b/src/services/user.py
@@ -26,6 +26,6 @@ def is_banned(user: User) -> bool:
 def get_open_tickets(user: User) -> Sequence[SupportTicket]:
     """Returns all open tickets created by :obj:`User`"""
     query = SupportTicket.select().where(
-        SupportTicket.user == user & SupportTicket.status == TicketStatus.OPEN
+        (SupportTicket.user == user) & (SupportTicket.status == TicketStatus.OPEN)
     )
     return query.execute()


### PR DESCRIPTION
Without the paranthesis, peewee used to generate a query like this:

```
SELECT "t1"."id", "t1"."user_id", "t1"."message", "t1"."support_message_id", "t1"."private_message_id", "t1"."status", "t1"."resolved_at", "t1"."resolved_by_id", "t1"."created_at", "t1"."updated_at" FROM "support_tickets" AS "t1" WHERE (({USER_ID} AND "t1"."status") = 0)
```

It would always return all the user IDs created by all users.

Updating the peewee query generates the following SQL query:

```
SELECT "t1"."id", "t1"."user_id", "t1"."message", "t1"."support_message_id", "t1"."private_message_id", "t1"."status", "t1"."resolved_at", "t1"."resolved_by_id", "t1"."created_at", "t1"."updated_at" FROM "support_tickets" AS "t1" WHERE (("t1"."user_id" = {USER_ID}) AND ("t1"."status" = 0))
```